### PR TITLE
Adding date tooltip

### DIFF
--- a/js/jwtview.js
+++ b/js/jwtview.js
@@ -363,6 +363,25 @@ export function initJwtView() {
     fireEvent($algRadio.get(0));
   }
 
+  // Check each line for numbers that look like a date and
+  // if it appears to be a date within a year of today,
+  // add a tooltip with the date.
+  function addTimeTooltip(instance, line, element){
+    var now = Date.now();
+    var oneYear = 356 * 24 * 60 * 60 * 1000;
+    var maxTime = now + oneYear;
+    var minTime = now - oneYear;
+    var children = element.getElementsByClassName("cm-number");
+
+    for (var i = 0; i < children.length; i++) {
+      var valueAsTime = children[i].innerText * 1000;
+      if (valueAsTime > minTime && valueAsTime < maxTime) {
+        // Number appears to be a time within 1 year of today's date. Add title to element.
+        children[i].title = new Date(valueAsTime);
+      }
+    }
+  }
+
   function refreshTokenEditor(instance) {
     tokenEditor.off('change', tokenEditorOnChangeListener);
 
@@ -425,6 +444,7 @@ export function initJwtView() {
 
   tokenEditor.on('change', tokenEditorOnChangeListener);
 
+  payloadEditor.on("renderLine", addTimeTooltip)
   payloadEditor.on('change',  refreshTokenEditor);
   headerEditor.on('change',   refreshTokenEditor);
 


### PR DESCRIPTION
### Description

Adds human readable date tootips by adding title to elements with class "cm-number" that contain a value within 1 year of today's date.

### References

Addresses Issue #8.

### Testing

Manually tested with Edge and Chrome by pasting JWTs and hovering over auth_time, iat, nvb, and iat times. 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
